### PR TITLE
feat: add OpenAI Codex provider

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -18,6 +18,9 @@ export const DEFAULT_CONFIG: GlobalConfig = {
     claude: {
       model: "claude-sonnet-4-20250514",
     },
+    codex: {
+      model: "o3",
+    },
   },
 
   keybindings: {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -33,7 +33,7 @@ function warnInvalidEnv(varName: string, value: string, expected: string): void 
  * Load configuration from environment variables
  *
  * Supported variables:
- * - OPENSWE_BACKEND: "opencode" | "claude"
+ * - OPENSWE_BACKEND: "opencode" | "claude" | "codex"
  * - OPENSWE_LOG_LEVEL: "debug" | "info" | "warn" | "error"
  */
 export function loadEnvConfig(): PartialConfig {
@@ -45,7 +45,7 @@ export function loadEnvConfig(): PartialConfig {
     if (isValidBackend(backend)) {
       config.ai = { backend }
     } else {
-      warnInvalidEnv("OPENSWE_BACKEND", backend, '"opencode" or "claude"')
+      warnInvalidEnv("OPENSWE_BACKEND", backend, '"opencode", "claude", or "codex"')
     }
   }
 

--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -132,7 +132,7 @@ function validateParsedConfig(parsed: unknown): PartialConfig {
     if (isValidBackend(ai.backend)) {
       config.ai.backend = ai.backend
     } else if (ai.backend !== undefined) {
-      warnInvalidConfig("ai.backend", ai.backend, '"opencode" or "claude"')
+      warnInvalidConfig("ai.backend", ai.backend, '"opencode", "claude", or "codex"')
     }
 
     if (ai.opencode && typeof ai.opencode === "object") {
@@ -146,6 +146,12 @@ function validateParsedConfig(parsed: unknown): PartialConfig {
       const cl = ai.claude as Record<string, unknown>
       config.ai.claude = {}
       if (isNonEmptyString(cl.model)) config.ai.claude.model = cl.model
+    }
+
+    if (ai.codex && typeof ai.codex === "object") {
+      const cx = ai.codex as Record<string, unknown>
+      config.ai.codex = {}
+      if (isNonEmptyString(cx.model)) config.ai.codex.model = cx.model
     }
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -99,6 +99,8 @@ function applyCLIOverrides(config: GlobalConfig, cli: CLIOverrides): GlobalConfi
       result.ai.opencode.model = cli.model
     } else if (activeBackend === "claude") {
       result.ai.claude.model = cli.model
+    } else if (activeBackend === "codex") {
+      result.ai.codex.model = cli.model
     }
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -7,7 +7,7 @@
 // ============================================================================
 
 /** Supported AI backends */
-export type AIBackend = "opencode" | "claude"
+export type AIBackend = "opencode" | "claude" | "codex"
 
 /** Log levels in order of verbosity */
 export type LogLevel = "debug" | "info" | "warn" | "error"
@@ -27,11 +27,17 @@ export interface ClaudeConfig {
   model: string
 }
 
+/** Codex-specific AI configuration */
+export interface CodexConfig {
+  model: string
+}
+
 /** AI backend configuration */
 export interface AIConfig {
   backend: AIBackend
   opencode: OpenCodeConfig
   claude: ClaudeConfig
+  codex: CodexConfig
 }
 
 /** Keyboard shortcut configuration */
@@ -97,7 +103,7 @@ export interface CLIOverrides {
 // ============================================================================
 
 /** Valid AI backend values */
-const VALID_BACKENDS: readonly AIBackend[] = ["opencode", "claude"]
+const VALID_BACKENDS: readonly AIBackend[] = ["opencode", "claude", "codex"]
 
 /** Valid log level values */
 const VALID_LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ interface CLIArgs {
   repo?: string
   setup?: boolean
   status?: boolean
-  backend?: "opencode" | "claude"
+  backend?: "opencode" | "claude" | "codex"
   model?: string
   debug?: boolean
 }
@@ -69,7 +69,7 @@ const argv = await yargs(hideBin(process.argv))
   })
   .option("backend", {
     type: "string",
-    choices: ["opencode", "claude"] as const,
+    choices: ["opencode", "claude", "codex"] as const,
     description: "AI backend to use",
   })
   .option("model", {
@@ -195,7 +195,7 @@ async function handleExistingProject(
   initFileLogging(join(logsDir, "openswe.log"))
 
   // Check prerequisites before launching TUI
-  const prereqResult = await checkPrerequisites()
+  const prereqResult = await checkPrerequisites(config.ai.backend)
   if (!prereqResult.success) {
     logger.error(formatPrerequisiteErrors(prereqResult))
     exitApp(1)

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,0 +1,104 @@
+/**
+ * OpenAI Codex provider implementation
+ *
+ * Supports the Codex CLI (https://github.com/openai/codex)
+ */
+
+import type { Provider, ProviderBranding, ParserPatterns, SpawnCommand } from "./types"
+import type { Session } from "../store"
+import type { CodexConfig } from "../config/types"
+
+// ============================================================================
+// Branding
+// ============================================================================
+
+const branding: ProviderBranding = {
+	displayName: "Codex",
+	shortName: "codex",
+	accentColor: "#10a37f",
+	secondaryColor: "#0d8c6d",
+	logoText: "CX",
+}
+
+// ============================================================================
+// Parser Patterns
+// ============================================================================
+
+const parserPatterns: ParserPatterns = {
+	workingRegex: /(?:starting|begin|entering).+(?:implementation|coding|execution)|(?:mode|status):\s*(?:implement|coding)|editing|writing.*file/i,
+	doneRegex: /\[?OPENSWE:DONE\]?|completed successfully|task completed/i,
+}
+
+// ============================================================================
+// Provider Implementation
+// ============================================================================
+
+export const codexProvider: Provider = {
+	id: "codex",
+	name: "Codex",
+	branding,
+	parserPatterns,
+
+	buildSpawnCommand(
+		_session: Session,
+		prompt?: string,
+		resumeSessionId?: string,
+		config?: Record<string, unknown>
+	): SpawnCommand {
+		const codexConfig = config as CodexConfig | undefined
+		const model = codexConfig?.model ?? "o3"
+
+		// Resume a previous session via the `codex resume` subcommand
+		if (resumeSessionId) {
+			const args = ["resume", resumeSessionId, "--model", model]
+			if (prompt) {
+				args.push(prompt)
+			}
+			return { command: "codex", args }
+		}
+
+		// Start a new interactive session
+		// No --full-auto: user can attach to tmux to review and approve actions
+		const args = ["--model", model]
+
+		if (prompt) {
+			args.push(prompt)
+		}
+
+		return {
+			command: "codex",
+			args,
+		}
+	},
+
+	async validateInstallation(): Promise<boolean> {
+		try {
+			const proc = Bun.spawn(["which", "codex"], {
+				stdout: "pipe",
+				stderr: "pipe",
+			})
+			const exitCode = await proc.exited
+			return exitCode === 0
+		} catch {
+			return false
+		}
+	},
+
+	async getVersion(): Promise<string | null> {
+		try {
+			const proc = Bun.spawn(["codex", "--version"], {
+				stdout: "pipe",
+				stderr: "pipe",
+			})
+			const exitCode = await proc.exited
+			if (exitCode !== 0) return null
+
+			const output = await new Response(proc.stdout).text()
+			// Codex outputs "codex-cli X.Y.Z"
+			const match = output.match(/v?(\d+\.\d+\.\d+(?:-[\w.]+)?)/)
+			return match ? match[1] ?? null : output.trim() || null
+		} catch {
+			return null
+		}
+	},
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,7 +2,7 @@
  * Provider system exports
  *
  * Abstract AI backend provider interface with implementations
- * for OpenCode and Claude Code.
+ * for OpenCode, Claude Code, and Codex.
  */
 
 // Registry functions
@@ -11,6 +11,7 @@ export { getProvider, getAllProviders, isProviderSupported } from "./registry"
 // Provider implementations
 export { openCodeProvider } from "./opencode"
 export { claudeProvider } from "./claude"
+export { codexProvider } from "./codex"
 
 // Types
 export type {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -8,6 +8,7 @@ import type { AIBackend } from "../config/types"
 import type { Provider } from "./types"
 import { openCodeProvider } from "./opencode"
 import { claudeProvider } from "./claude"
+import { codexProvider } from "./codex"
 
 // ============================================================================
 // Registry
@@ -16,6 +17,7 @@ import { claudeProvider } from "./claude"
 const providers: Map<AIBackend, Provider> = new Map([
 	["opencode", openCodeProvider],
 	["claude", claudeProvider],
+	["codex", codexProvider],
 ])
 
 // ============================================================================

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -28,7 +28,7 @@ export type Status =
 
 /** Backend session reference for AI integrations */
 export interface AISessionData {
-  backend: "opencode" | "claude"
+  backend: "opencode" | "claude" | "codex"
   sessionId?: string
   [key: string]: unknown
 }
@@ -168,7 +168,7 @@ const VALID_STATUSES: readonly Status[] = [
   "failed",
 ]
 
-const VALID_AI_BACKENDS = ["opencode", "claude"] as const
+const VALID_AI_BACKENDS = ["opencode", "claude", "codex"] as const
 
 /** Check if a value is a valid Phase */
 export function isValidPhase(val: unknown): val is Phase {
@@ -185,7 +185,7 @@ export function isValidAISessionData(val: unknown): val is AISessionData {
   if (typeof val !== "object" || val === null) return false
 
   const backend = (val as { backend?: unknown }).backend
-  if (backend !== "opencode" && backend !== "claude") return false
+  if (typeof backend !== "string" || !VALID_AI_BACKENDS.includes(backend as typeof VALID_AI_BACKENDS[number])) return false
 
   const sessionId = (val as { sessionId?: unknown }).sessionId
   if (sessionId !== undefined && typeof sessionId !== "string") return false

--- a/src/utils/prerequisites.ts
+++ b/src/utils/prerequisites.ts
@@ -6,6 +6,7 @@
 
 import { checkGitInstalled } from "../git"
 import { checkGhCli } from "../github"
+import type { AIBackend } from "../config/types"
 
 // ============================================================================
 // Types
@@ -31,10 +32,12 @@ export interface PrerequisiteResult {
  * Verifies:
  * - Git is installed
  * - GitHub CLI (gh) is installed and authenticated
+ * - The configured AI backend CLI is available
  *
+ * @param backend - The configured AI backend to check (defaults to "opencode")
  * @returns Result indicating whether prerequisites are met
  */
-export async function checkPrerequisites(): Promise<PrerequisiteResult> {
+export async function checkPrerequisites(backend: AIBackend = "opencode"): Promise<PrerequisiteResult> {
   const errors: string[] = []
   const warnings: string[] = []
 
@@ -56,11 +59,12 @@ export async function checkPrerequisites(): Promise<PrerequisiteResult> {
     )
   }
 
-  // Check if opencode is available (warning only, not required for all operations)
-  const opencodeAvailable = await isCommandAvailable("opencode")
-  if (!opencodeAvailable) {
+  // Check if the configured backend CLI is available (warning only)
+  const backendCommand = backend === "opencode" ? "opencode" : backend === "claude" ? "claude" : "codex"
+  const backendAvailable = await isCommandAvailable(backendCommand)
+  if (!backendAvailable) {
     warnings.push(
-      "opencode command not found in PATH. Sessions won't be able to start until it's installed."
+      `${backendCommand} command not found in PATH. Sessions won't be able to start until it's installed.`
     )
   }
 

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -12,7 +12,7 @@ import { isValidOwnerRepo } from "../git/repo"
 // ============================================================================
 
 /** AI backend options */
-export type AIBackendChoice = "opencode" | "claude"
+export type AIBackendChoice = "opencode" | "claude" | "codex"
 
 // ============================================================================
 // Repository Input
@@ -65,6 +65,11 @@ export async function promptAiBackend(): Promise<AIBackendChoice | symbol> {
         value: "claude" as const,
         label: "Claude",
         hint: "Anthropic's Claude via API",
+      },
+      {
+        value: "codex" as const,
+        label: "Codex",
+        hint: "OpenAI's Codex CLI agent",
       },
     ],
   })


### PR DESCRIPTION
## Summary

Adds OpenAI Codex as a third AI backend provider, following the existing pattern established by Claude Code and OpenCode.

- **New provider** (`src/providers/codex.ts`): Branding (OpenAI green `#10a37f`, logo `CX`), parser patterns, spawn command (`codex --model <model> <prompt>`, `codex resume <id>`), and CLI validation
- **Full integration** across config types, defaults, TOML validation, env vars, CLI args, wizard prompts, store types, and provider registry
- **Dynamic prerequisites check**: Now checks the configured backend's CLI tool instead of hardcoding `opencode`

## Details

The Codex provider runs interactively (no `--full-auto` flag) so users can attach to tmux sessions to review and approve actions, matching the approach used by the Claude Code provider.

### Files changed (12)

| File | Change |
|------|--------|
| `src/providers/codex.ts` | New provider implementation |
| `src/providers/registry.ts` | Register codexProvider |
| `src/providers/index.ts` | Export codexProvider |
| `src/config/types.ts` | Add `"codex"` to `AIBackend`, `CodexConfig`, `AIConfig` |
| `src/config/defaults.ts` | Default model: `o3` |
| `src/config/index.ts` | CLI override branch for codex |
| `src/config/global.ts` | TOML validation for `[ai.codex]` |
| `src/config/env.ts` | Updated env var warning |
| `src/store/types.ts` | Add codex to `AISessionData`, validation |
| `src/index.ts` | CLI `--backend` choices, dynamic prereq check |
| `src/wizard/prompts.ts` | Codex option in setup wizard |
| `src/utils/prerequisites.ts` | Dynamic backend CLI check |

Closes #3