### PR TITLE
feat: make 'openswe' the active process in terminal

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -314,7 +314,11 @@ export function App(props: AppProps) {
             if (updatedSession?.status === "active") {
               // Resize to full terminal size for interactive use
               await sessionManager.resizeSession(session.id, termSize().cols, termSize().rows)
-              
+
+              // Set terminal and window title to "openswe"
+              process.stdout.write("\x1b]0;openswe\x07")
+              await sessionManager.setWindowTitle(session.id, "openswe")
+
               const cmd = sessionManager.getAttachCommand(session.id)
 
               // Suspend OpenTUI before yielding terminal to tmux

--- a/src/core/process-manager.ts
+++ b/src/core/process-manager.ts
@@ -49,4 +49,9 @@ export interface ProcessManager {
    * Resize the session terminal
    */
   resize(id: string, cols: number, rows: number): Promise<void>
+
+  /**
+   * Set the window title for the session
+   */
+  setWindowTitle(id: string, title: string): Promise<void>
 }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -349,6 +349,13 @@ export class SessionManager {
     await this.processManager.resize(sessionId, cols, rows)
   }
 
+  /**
+   * Set the window title for the session
+   */
+  async setWindowTitle(sessionId: string, title: string): Promise<void> {
+    await this.processManager.setWindowTitle(sessionId, title)
+  }
+
   private cleanupSession(sessionId: string) {
     const active = this.activeSessions.get(sessionId)
     if (active) {

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -210,4 +210,18 @@ export class TmuxManager implements ProcessManager {
     // resize-window sets the size of the window (and thus the detached session)
     await Bun.spawn(["tmux", "resize-window", "-t", sessionName, "-x", cols.toString(), "-y", rows.toString()], { stderr: "ignore" }).exited
   }
+
+  async setWindowTitle(id: string, title: string): Promise<void> {
+    const sessionName = this.getSessionName(id)
+    // Disable automatic window renaming
+    await Bun.spawn([
+      "tmux", "set-option", "-t", sessionName,
+      "automatic-rename", "off"
+    ], { stderr: "ignore" }).exited
+
+    // Set the window title
+    await Bun.spawn([
+      "tmux", "rename-window", "-t", sessionName, title
+    ], { stderr: "ignore" }).exited
+  }
 }


### PR DESCRIPTION
## Summary

When users attach to a tmux session (pressing Enter in the TUI), the terminal tab/window title now displays **'openswe'** instead of the folder path.

## Changes

- Added `setWindowTitle()` method to `TmuxManager` that:
  - Disables automatic window renaming in tmux
  - Renames the tmux window to "openswe"
  
- Added `setWindowTitle()` method signature to `ProcessManager` interface

- Added `setWindowTitle()` wrapper to `SessionManager`

- Modified attachment flow in `App.tsx` to:
  - Set terminal title via OSC escape sequence (`\x1b]0;openswe\x07`)
  - Set tmux window title before attaching

## How it works

1. User presses Enter to attach to a session
2. Terminal title is set to "openswe" via OSC escape sequence
3. Tmux window is renamed to "openswe" via `tmux rename-window`
4. User attaches to the session with the title visible

## Testing

1. Start openswe TUI
2. Create or select a session
3. Press Enter to attach
4. Verify terminal tab/window shows "openswe" as the title

Closes #11