### PR TITLE
feat: remove default model configuration for all AI providers

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,14 +12,13 @@ export const DEFAULT_CONFIG: GlobalConfig = {
   ai: {
     backend: "opencode",
     opencode: {
-      model: "claude-sonnet",
       provider: "anthropic",
     },
     claude: {
-      model: "claude-sonnet-4-20250514",
+      // Provider uses its own default model
     },
     codex: {
-      model: "gpt-5-codex",
+      // Provider uses its own default model
     },
   },
 

--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -138,20 +138,17 @@ function validateParsedConfig(parsed: unknown): PartialConfig {
     if (ai.opencode && typeof ai.opencode === "object") {
       const oc = ai.opencode as Record<string, unknown>
       config.ai.opencode = {}
-      if (isNonEmptyString(oc.model)) config.ai.opencode.model = oc.model
       if (isNonEmptyString(oc.provider)) config.ai.opencode.provider = oc.provider
     }
 
     if (ai.claude && typeof ai.claude === "object") {
-      const cl = ai.claude as Record<string, unknown>
+      // Provider uses its own default model - no configuration needed
       config.ai.claude = {}
-      if (isNonEmptyString(cl.model)) config.ai.claude.model = cl.model
     }
 
     if (ai.codex && typeof ai.codex === "object") {
-      const cx = ai.codex as Record<string, unknown>
+      // Provider uses its own default model - no configuration needed
       config.ai.codex = {}
-      if (isNonEmptyString(cx.model)) config.ai.codex.model = cx.model
     }
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,17 +93,6 @@ function applyCLIOverrides(config: GlobalConfig, cli: CLIOverrides): GlobalConfi
     result.ai.backend = cli.backend
   }
 
-  if (cli.model !== undefined) {
-    const activeBackend = result.ai.backend
-    if (activeBackend === "opencode") {
-      result.ai.opencode.model = cli.model
-    } else if (activeBackend === "claude") {
-      result.ai.claude.model = cli.model
-    } else if (activeBackend === "codex") {
-      result.ai.codex.model = cli.model
-    }
-  }
-
   if (cli.debug === true) {
     result.advanced.logLevel = "debug"
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,18 +18,17 @@ export type LogLevel = "debug" | "info" | "warn" | "error"
 
 /** OpenCode-specific AI configuration */
 export interface OpenCodeConfig {
-  model: string
   provider: string
 }
 
 /** Claude-specific AI configuration */
 export interface ClaudeConfig {
-  model: string
+  // Provider uses its own default model
 }
 
 /** OpenAI Codex-specific AI configuration */
 export interface CodexConfig {
-  model: string
+  // Provider uses its own default model
 }
 
 /** AI backend configuration */
@@ -94,7 +93,6 @@ export type PartialConfig = DeepPartial<GlobalConfig>
 /** CLI flags that can override configuration */
 export interface CLIOverrides {
   backend?: AIBackend
-  model?: string
   debug?: boolean
 }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -177,14 +177,13 @@ export class SessionManager {
       // Use session's backend if available, otherwise fall back to global config
       const backend = options.aiSessionData?.backend ?? session.aiSessionData?.backend ?? this.config.ai.backend
       const provider = getProvider(backend)
-      const providerConfig = this.config.ai[backend] as unknown as Record<string, unknown>
 
       // Build spawn command using the session's provider
+      // Provider uses its own default model - no model configuration needed
       const spawnCmd = provider.buildSpawnCommand(
         session,
         options.prompt,
-        options.resumeSessionId,
-        providerConfig
+        options.resumeSessionId
       )
 
       // Filter env to remove undefined values

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ interface CLIArgs {
   setup?: boolean
   status?: boolean
   backend?: "opencode" | "claude"
-  model?: string
   debug?: boolean
 }
 
@@ -72,10 +71,7 @@ const argv = await yargs(hideBin(process.argv))
     choices: ["opencode", "claude", "codex"] as const,
     description: "AI backend to use",
   })
-  .option("model", {
-    type: "string",
-    description: "AI model to use (e.g. claude-3-5-sonnet-20240620)",
-  })
+
   .option("debug", {
     type: "boolean",
     description: "Enable debug logging",
@@ -94,7 +90,6 @@ async function main() {
   // Load configuration with CLI overrides
   const config = await loadConfig({
     backend: argv.backend as AIBackend | undefined,
-    model: argv.model,
     debug: argv.debug,
   })
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -6,7 +6,6 @@
 
 import type { Provider, ProviderBranding, ParserPatterns, SpawnCommand } from "./types"
 import type { Session } from "../store"
-import type { ClaudeConfig } from "../config/types"
 
 // ============================================================================
 // Branding
@@ -44,16 +43,11 @@ export const claudeProvider: Provider = {
 		_session: Session,
 		prompt?: string,
 		resumeSessionId?: string,
-		config?: Record<string, unknown>
+		_config?: Record<string, unknown>
 	): SpawnCommand {
-		const claudeConfig = config as ClaudeConfig | undefined
-		const model = claudeConfig?.model ?? "claude-sonnet-4-20250514"
-
 		// Run Claude Code interactively (no --print flag)
 		// User can attach to the tmux session to review and approve changes
-		const args = [
-			"--model", model,
-		]
+		const args: string[] = []
 
 		if (resumeSessionId) {
 			args.push("--resume", resumeSessionId)

--- a/src/providers/codex.test.ts
+++ b/src/providers/codex.test.ts
@@ -89,29 +89,15 @@ describe("codexProvider", () => {
 	// ============================================================================
 
 	describe("buildSpawnCommand", () => {
-		test("builds basic command with default model", () => {
+		test("builds basic command with prompt", () => {
 			const session = makeSession()
 			const result = codexProvider.buildSpawnCommand(session, "Fix the bug")
 
 			expect(result.command).toBe("codex")
 			expect(result.args).toContain("--full-auto")
-			expect(result.args).toContain("--model")
-			expect(result.args).toContain("gpt-5-codex")
 			expect(result.args).toContain("Fix the bug")
-		})
-
-		test("uses custom model from config", () => {
-			const session = makeSession()
-			const result = codexProvider.buildSpawnCommand(
-				session,
-				"Fix the bug",
-				undefined,
-				{ model: "o3-pro" }
-			)
-
-			expect(result.args).toContain("--model")
-			expect(result.args).toContain("o3-pro")
-			expect(result.args).not.toContain("gpt-5-codex")
+			// Provider uses its own default model - no --model flag
+			expect(result.args).not.toContain("--model")
 		})
 
 		test("builds command without prompt", () => {
@@ -120,10 +106,10 @@ describe("codexProvider", () => {
 
 			expect(result.command).toBe("codex")
 			expect(result.args).toContain("--full-auto")
-			expect(result.args).toContain("--model")
-			expect(result.args).toContain("gpt-5-codex")
+			// Provider uses its own default model - no --model flag
+			expect(result.args).not.toContain("--model")
 			// No prompt in args
-			expect(result.args).toEqual(["--full-auto", "--model", "gpt-5-codex"])
+			expect(result.args).toEqual(["--full-auto"])
 		})
 
 		test("builds resume command with session ID", () => {
@@ -138,8 +124,8 @@ describe("codexProvider", () => {
 			expect(result.args[0]).toBe("resume")
 			expect(result.args[1]).toBe("prev-session-123")
 			expect(result.args).toContain("--full-auto")
-			expect(result.args).toContain("--model")
-			expect(result.args).toContain("gpt-5-codex")
+			// Provider uses its own default model - no --model flag
+			expect(result.args).not.toContain("--model")
 		})
 
 		test("resume command includes prompt when provided", () => {
@@ -153,20 +139,6 @@ describe("codexProvider", () => {
 			expect(result.args[0]).toBe("resume")
 			expect(result.args[1]).toBe("prev-session-123")
 			expect(result.args).toContain("Continue fixing")
-		})
-
-		test("resume command uses custom model from config", () => {
-			const session = makeSession()
-			const result = codexProvider.buildSpawnCommand(
-				session,
-				undefined,
-				"prev-session-123",
-				{ model: "o3" }
-			)
-
-			expect(result.args).toContain("--model")
-			expect(result.args).toContain("o3")
-			expect(result.args).not.toContain("gpt-5-codex")
 		})
 	})
 })

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -6,7 +6,6 @@
 
 import type { Provider, ProviderBranding, ParserPatterns, SpawnCommand } from "./types"
 import type { Session } from "../store"
-import type { CodexConfig } from "../config/types"
 
 // ============================================================================
 // Branding
@@ -44,17 +43,13 @@ export const codexProvider: Provider = {
 		_session: Session,
 		prompt?: string,
 		resumeSessionId?: string,
-		config?: Record<string, unknown>
+		_config?: Record<string, unknown>
 	): SpawnCommand {
-		const codexConfig = config as CodexConfig | undefined
-		const model = codexConfig?.model ?? "gpt-5-codex"
-
 		// Resume a previous session
 		if (resumeSessionId) {
 			const args = [
 				"resume", resumeSessionId,
 				"--full-auto",
-				"--model", model,
 			]
 
 			if (prompt) {
@@ -70,7 +65,6 @@ export const codexProvider: Provider = {
 		// Start a new session with --full-auto for non-interactive use
 		const args = [
 			"--full-auto",
-			"--model", model,
 		]
 
 		// Add the prompt as the final positional argument

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -6,7 +6,6 @@
 
 import type { Provider, ProviderBranding, ParserPatterns, SpawnCommand } from "./types"
 import type { Session } from "../store"
-import type { OpenCodeConfig } from "../config/types"
 
 // ============================================================================
 // Branding
@@ -44,10 +43,8 @@ export const openCodeProvider: Provider = {
 		_session: Session,
 		prompt?: string,
 		resumeSessionId?: string,
-		config?: Record<string, unknown>
+		_config?: Record<string, unknown>
 	): SpawnCommand {
-		const openCodeConfig = config as OpenCodeConfig | undefined
-
 		const args = []
 
 		// Without them, opencode launches in interactive TUI mode


### PR DESCRIPTION
## Summary

Removes hardcoded default models and the `--model` CLI flag. Each AI provider now uses its own built-in default model instead of OpenSWE overriding it.

## Changes

- **CLI**: Removed `--model` option from CLI arguments
- **Config Types**: Removed `model` field from `OpenCodeConfig`, `ClaudeConfig`, and `CodexConfig` interfaces
- **Config Defaults**: Removed default model values (gpt-5-codex, claude-sonnet-4-20250514, claude-sonnet)
- **Config Loading**: Removed model parsing from TOML config validation and CLI overrides
- **Providers**: 
  - Removed `--model` flag from Codex provider
  - Removed `--model` flag from Claude provider
  - OpenCode provider unchanged (didn't use model config)
- **Session Manager**: Removed providerConfig from buildSpawnCommand
- **Tests**: Updated to verify providers don't include `--model` flag

## Behavior Change

**Before:**
- OpenSWE specified models like `gpt-5-codex`, `claude-sonnet-4-20250514`
- Users could override via `--model` CLI flag or config file

**After:**
- Each CLI tool uses its own default model
- No OpenSWE-level model configuration
- Users configure models via their AI CLI's native methods if needed

## Testing

- All 58 tests pass
- Type check clean
- Manual verification: providers no longer pass `--model` flag

Closes #10