### PR TITLE
feat: add 'r' button to reload AI agent session

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -287,9 +287,17 @@ export function App(props: AppProps) {
         break
       }
 
-      case "r":
-        loadSessions()
+      case "r": {
+        const session = selectedSession()
+        if (session) {
+          sessionManager.reloadSession(session.id).then(() => {
+            loadSessions()
+          }).catch((error) => {
+            logger.error("Failed to reload session:", error)
+          })
+        }
         break
+      }
 
       case "return":
         // Full takeover mode - start session if needed, then attach

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -34,7 +34,7 @@ const KEY_SECTIONS: KeySection[] = [
       { key: "n", description: "New session" },
       { key: "d", description: "Delete session" },
       { key: "p", description: "Pause/resume session" },
-      { key: "r", description: "Refresh data" },
+      { key: "r", description: "Reload session" },
     ],
   },
   {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -16,6 +16,7 @@ import {
   setLines,
   isValidPhase,
   getProject,
+  resetSessionForReload,
 } from "../store"
 import type { AISessionData } from "../store"
 import type { GlobalConfig, AIBackend } from "../config"
@@ -30,6 +31,7 @@ import { mkdir, open } from "fs/promises"
 import { getProvider } from "../providers"
 import type { Provider } from "../providers"
 import { createWorktree } from "../git"
+import { generateSWEPrompt } from "../prompts"
 
 export interface StartSessionOptions {
   sessionId: string
@@ -315,6 +317,41 @@ export class SessionManager {
     this.cleanupSession(sessionId)
     updateSessionStatus(sessionId, "queued")
     setPid(sessionId, null)
+  }
+
+  /**
+   * Reload a session - stop it and restart with preserved AI session data
+   *
+   * This closes the current session and restarts it using the same AI provider
+   * and session ID, allowing the conversation to continue from where it left off.
+   *
+   * @param sessionId - The session to reload
+   */
+  async reloadSession(sessionId: string): Promise<void> {
+    const session = getSession(sessionId)
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+
+    logger.info(`Reloading session "${session.name}" (${sessionId})`)
+
+    // 1. Stop existing session if running
+    if (this.activeSessions.has(sessionId)) {
+      await this.stopSession(sessionId)
+    }
+
+    // 2. Reset session state in DB (clear output buffer, reset phase/status)
+    resetSessionForReload(sessionId)
+
+    // 3. Restart with preserved aiSessionData
+    await this.startSession({
+      sessionId: session.id,
+      prompt: session.issueNumber ? generateSWEPrompt(session) : undefined,
+      resumeSessionId: session.aiSessionData?.sessionId,
+      aiSessionData: session.aiSessionData,
+    })
+
+    logger.info(`Session "${session.name}" reloaded successfully`)
   }
 
   /**

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -78,6 +78,7 @@ export {
   setPid,
   setAISessionData,
   getAISessionData,
+  resetSessionForReload,
   deleteSession,
   deleteAllSessions,
 } from "./sessions"

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types"
 import { isValidAISessionData } from "./types"
 import { logger } from "../utils/logger"
+import { clearBuffer } from "./buffers"
 
 // ============================================================================
 // Database Row Type
@@ -425,6 +426,36 @@ export function setAISessionData(id: string, data: AISessionData | null): void {
 export function getAISessionData(id: string): AISessionData | null {
   const session = getSession(id)
   return session?.aiSessionData ?? null
+}
+
+/**
+ * Reset a session for reload
+ *
+ * Clears output buffer, resets phase/status to pending/queued,
+ * clears PID and retry count, and clears attention reason.
+ * Preserves aiSessionData for session continuity.
+ *
+ * @param id - Session ID
+ */
+export function resetSessionForReload(id: string): void {
+  const db = getDatabase()
+  const now = nowISO()
+
+  db.query(
+    `UPDATE sessions 
+     SET phase = 'pending', 
+         status = 'queued', 
+         pid = NULL,
+         retry_count = 0,
+         attention_reason = NULL,
+         updated_at = ?
+     WHERE id = ?`
+  ).run(now, id)
+
+  // Clear output buffer for clean slate
+  clearBuffer(id)
+
+  logger.debug("Session reset for reload", { sessionId: id })
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This PR implements the feature requested in #12 - adding the ability to reload an AI agent session by pressing the 'r' key.

## Changes

- **Session reload functionality**: When 'r' is pressed on a selected session:
  1. Stops the existing session (kills tmux, stops log tail)
  2. Resets session state in database (phase→pending, status→queued)
  3. Clears the output buffer for a clean slate
  4. Restarts the session using the same AI backend and preserved `aiSessionData.sessionId`
  5. The AI agent continues the conversation from where it left off

- **New functions added**:
  - `resetSessionForReload()` in `src/store/sessions.ts` - resets session state
  - `reloadSession()` in `SessionManager` - orchestrates the reload process

- **UI updates**:
  - 'r' keybinding changed from "Refresh data" to "Reload session"
  - Help modal updated to reflect new functionality

## Behavior

- Works on sessions in **any state** (active, paused, failed, queued, completed, needs_attention)
- No confirmation dialog (quick iteration)
- Clears output history (clean slate)
- Preserves AI session continuity via `aiSessionData.sessionId`

## Testing

- [x] Type check passes (`bunx tsc --noEmit`)
- [ ] Manual testing recommended

Closes #12