### PR TITLE
fix: fill issue selector modal viewport

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,6 +13,7 @@ export interface FooterProps {
 }
 
 const BOLD = 1
+export const FOOTER_HEIGHT = 1
 
 export function Footer(props: FooterProps) {
   const colors = useColors()
@@ -20,7 +21,7 @@ export function Footer(props: FooterProps) {
     <box
       flexDirection="row"
       width="100%"
-      height={1}
+      height={FOOTER_HEIGHT}
       backgroundColor={props.bgColor || colors().bg.secondary}
       paddingLeft={1}
       paddingRight={1}

--- a/src/components/IssueSelectorModal.tsx
+++ b/src/components/IssueSelectorModal.tsx
@@ -6,7 +6,7 @@ import { fetchIssues, formatRelativeTime, type GitHubIssue, type IssueState } fr
 import { createSessionFromIssue, findNextAvailableWorktreeName } from "./session-utils"
 import { ScrollableText } from "./ScrollableText"
 import { useColors, borders } from "./theme"
-import { Footer } from "./Footer"
+import { Footer, FOOTER_HEIGHT } from "./Footer"
 import { logger } from "../utils/logger"
 
 // Bold attribute constant
@@ -15,9 +15,12 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 const MODAL_WIDTH = 80
 const MODAL_HEIGHT = 24
 const HEADER_HEIGHT = 1
-const FOOTER_HEIGHT = 1
 const CONTENT_PADDING_TOP = 1
-const VISIBLE_ISSUE_COUNT = Math.max(1, MODAL_HEIGHT - HEADER_HEIGHT - FOOTER_HEIGHT - CONTENT_PADDING_TOP - 2)
+const BORDER_HEIGHT = 2
+const VISIBLE_ISSUE_COUNT = Math.max(
+  1,
+  MODAL_HEIGHT - HEADER_HEIGHT - FOOTER_HEIGHT - CONTENT_PADDING_TOP - BORDER_HEIGHT,
+)
 
 /** State filter options */
 const STATE_FILTERS: IssueState[] = ["open", "closed", "all"]


### PR DESCRIPTION
## Summary
- derive the issue list viewport from the modal height instead of capping it at 7 rows
- reuse the same visible-row count for list rendering and keyboard scrolling
- keep the issue selector content filling the available modal space

## Testing
- bunx tsc --noEmit

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved issue selector modal to dynamically calculate visible items based on modal layout dimensions, replacing fixed pagination logic.
  * Introduced layout constants for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->