### PR TITLE
fix: correct session open timer

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -39,7 +39,7 @@ import { useTheme } from "../theme"
 import { logger } from "../utils/logger"
 import { copyToClipboard } from "../utils/clipboard"
 
-/** Refresh interval for polling data (24 fps) */
+/** Refresh interval for polling data */
 const REFRESH_INTERVAL = (1/60) * 1000
 
 export function App(props: AppProps) {
@@ -210,8 +210,8 @@ export function App(props: AppProps) {
     const session = selectedSession()
     if (session) {
       // Track session start time for duration display
-      if (session.status === "active" && session.createdAt) {
-        setSessionStartedAt(new Date(session.createdAt))
+      if (session.status === "active" && session.openedAt) {
+        setSessionStartedAt(new Date(session.openedAt))
         
         // Resize immediately on selection, but only if not attaching
         if (!isAttaching()) {

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -8,7 +8,7 @@
  * - Footer: Session duration + attach hint
  */
 
-import { Show, createMemo, For } from "solid-js"
+import { Show, createMemo, createSignal, For, onCleanup, onMount } from "solid-js"
 import type { PreviewProps } from "./types"
 import type { Session } from "../store"
 import { getPhaseProgress } from "./types"
@@ -27,10 +27,10 @@ const VERSION = "v0.1.0" // TODO: Get from package.json or config
 /**
  * Format duration in human-readable form
  */
-function formatDuration(startedAt: Date | undefined): string {
+function formatDuration(startedAt: Date | undefined, now: number): string {
   if (!startedAt) return ""
 
-  const diff = Date.now() - startedAt.getTime()
+  const diff = Math.max(0, now - startedAt.getTime())
   const seconds = Math.floor(diff / 1000)
 
   if (seconds < 60) return `${seconds}s`
@@ -84,9 +84,20 @@ function StatusBanner(props: { session: Session }) {
 
 export function Preview(props: PreviewProps) {
   const colors = useColors()
-  const duration = createMemo(() => formatDuration(props.startedAt))
+  const [now, setNow] = createSignal(Date.now())
+  const duration = createMemo(() => formatDuration(props.startedAt, now()))
   const isActive = createMemo(() => props.session?.status === "active")
   const isPaused = createMemo(() => props.session?.status === "paused")
+
+  onMount(() => {
+    const interval = setInterval(() => {
+      setNow(Date.now())
+    }, 1000)
+
+    onCleanup(() => {
+      clearInterval(interval)
+    })
+  })
 
   // Resolve provider branding from session data if available, otherwise fall back to global prop
   const resolvedBranding = createMemo(() => {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -173,11 +173,6 @@ export class SessionManager {
     }
 
     try {
-      updateSessionStatus(session.id, "active")
-
-      // Auto-transition phase: planning if prompt-driven, working if interactive
-      updateSessionPhase(session.id, options.prompt ? "planning" : "working")
-
       const logPath = getSessionLogPath(this.projectRoot, session.id)
       await this.ensureLogFile(logPath)
 
@@ -295,6 +290,10 @@ export class SessionManager {
         logPath
       )
 
+      updateSessionStatus(session.id, "active")
+
+      // Auto-transition phase: planning if prompt-driven, working if interactive
+      updateSessionPhase(session.id, options.prompt ? "planning" : "working")
       setPid(session.id, pid)
 
       // Start tailing logs for parsing

--- a/src/providers/claude.test.ts
+++ b/src/providers/claude.test.ts
@@ -19,6 +19,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 		tokensUsed: 0,
 		pid: null,
 		aiSessionData: null,
+		openedAt: null,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 		...overrides,

--- a/src/providers/codex.test.ts
+++ b/src/providers/codex.test.ts
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 		tokensUsed: 0,
 		pid: null,
 		aiSessionData: null,
+		openedAt: null,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 		...overrides,

--- a/src/providers/opencode.test.ts
+++ b/src/providers/opencode.test.ts
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 		tokensUsed: 0,
 		pid: null,
 		aiSessionData: null,
+		openedAt: null,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 		...overrides,

--- a/src/store/db.test.ts
+++ b/src/store/db.test.ts
@@ -73,9 +73,9 @@ describe("Database Initialization", () => {
     expect(db).toBeDefined()
   })
 
-  test("schema version is 2", () => {
+  test("schema version is 3", () => {
     const version = getSchemaVersion()
-    expect(version).toBe(2)
+    expect(version).toBe(3)
   })
 
   test("tables are created", () => {
@@ -206,6 +206,7 @@ describe("Session Operations", () => {
     expect(session.retryCount).toBe(0)
     expect(session.tokensUsed).toBe(0)
     expect(session.pid).toBeNull()
+    expect(session.openedAt).toBeNull()
   })
 
   test("createSession with issue data", () => {
@@ -360,6 +361,39 @@ describe("Session Operations", () => {
     const updated = getSession(session.id)!
     expect(updated.status).toBe("active")
     expect(updated.attentionReason).toBeNull()
+    expect(updated.openedAt).toBeDefined()
+  })
+
+  test("updateSessionStatus sets openedAt when activating and preserves it while active", async () => {
+    const session = createSession({
+      name: "test-session",
+      worktreePath: "/path/to/worktree",
+      branchName: "openswe/test-session",
+    })
+
+    updateSessionStatus(session.id, "active")
+    const firstOpenedAt = getSession(session.id)!.openedAt
+
+    expect(firstOpenedAt).toBeDefined()
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    updateSessionStatus(session.id, "active")
+    expect(getSession(session.id)!.openedAt).toBe(firstOpenedAt)
+  })
+
+  test("updateSessionStatus clears openedAt when queueing", () => {
+    const session = createSession({
+      name: "test-session",
+      worktreePath: "/path/to/worktree",
+      branchName: "openswe/test-session",
+    })
+
+    updateSessionStatus(session.id, "active")
+    expect(getSession(session.id)!.openedAt).toBeDefined()
+
+    updateSessionStatus(session.id, "queued")
+    expect(getSession(session.id)!.openedAt).toBeNull()
   })
 
   test("incrementRetryCount increments and returns new value", () => {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -165,8 +165,19 @@ export function createDatabaseManager(): DatabaseManager {
       database.exec("INSERT OR REPLACE INTO schema_version (version) VALUES (2)")
     }
 
-    // Add future migrations here:
-    // if (version < 3) { migrateTo3() }
+    // Migration to version 3: Add opened_at column
+    if (version < 3) {
+      const columns = database
+        .query<{ name: string }, []>("PRAGMA table_info(sessions)")
+        .all()
+      const hasColumn = columns.some((col) => col.name === "opened_at")
+
+      if (!hasColumn) {
+        database.exec("ALTER TABLE sessions ADD COLUMN opened_at TEXT")
+      }
+
+      database.exec("INSERT OR REPLACE INTO schema_version (version) VALUES (3)")
+    }
   }
 
   const withTransaction = <T>(fn: () => T): T => {

--- a/src/store/schema.sql
+++ b/src/store/schema.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   tokens_used INTEGER NOT NULL DEFAULT 0,
   pid INTEGER,
   ai_session_data TEXT,                   -- JSON: {backend, sessionId, ...}
+  opened_at TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -38,6 +38,7 @@ interface SessionRow {
   tokens_used: number
   pid: number | null
   ai_session_data: string | null
+  opened_at: string | null
   created_at: string
   updated_at: string
 }
@@ -66,6 +67,7 @@ function rowToSession(row: SessionRow): Session {
     tokensUsed: row.tokens_used,
     pid: row.pid,
     aiSessionData: parseAISessionData(row.ai_session_data),
+    openedAt: row.opened_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -207,8 +209,9 @@ export function createSession(data: CreateSessionInput): Session {
       id, name, issue_number, issue_title, issue_body, issue_url,
       worktree_path, branch_name, phase, status,
       attention_reason, retry_count, tokens_used, pid, ai_session_data,
+      opened_at,
       created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 'queued', NULL, 0, 0, NULL, ?, ?, ?)`
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 'queued', NULL, 0, 0, NULL, ?, NULL, ?, ?)`
   ).run(
     id,
     data.name,
@@ -241,6 +244,7 @@ export function createSession(data: CreateSessionInput): Session {
     tokensUsed: 0,
     pid: null,
     aiSessionData: data.aiSessionData ?? null,
+    openedAt: null,
     createdAt: now,
     updatedAt: now,
   }
@@ -306,6 +310,10 @@ export function updateSession(id: string, data: UpdateSessionInput): Session {
     updates.push("ai_session_data = ?")
     values.push(serializeAISessionData(data.aiSessionData))
   }
+  if (data.openedAt !== undefined) {
+    updates.push("opened_at = ?")
+    values.push(data.openedAt)
+  }
 
   values.push(id)
 
@@ -341,9 +349,20 @@ export function updateSessionStatus(
   status: Status,
   reason?: string
 ): void {
+  const current = getSession(id)
+  const openedAt =
+    status === "active"
+      ? current?.status === "active" && current.openedAt
+        ? current.openedAt
+        : nowISO()
+      : status === "queued"
+        ? null
+        : current?.openedAt
+
   updateSession(id, {
     status,
     attentionReason: status === "needs_attention" ? reason ?? null : null,
+    openedAt,
   })
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -70,6 +70,8 @@ export interface Session {
   pid: number | null
   /** AI backend session reference data */
   aiSessionData: AISessionData | null
+  /** ISO timestamp when session was last opened/running */
+  openedAt: string | null
   /** ISO timestamp when session was created */
   createdAt: string
   /** ISO timestamp when session was last updated */
@@ -98,6 +100,7 @@ export interface UpdateSessionInput {
   tokensUsed?: number
   pid?: number | null
   aiSessionData?: AISessionData | null
+  openedAt?: string | null
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- track the actual session open time separately from session creation time
- start the open timer only after tmux spawn succeeds and use that persisted timestamp in the preview
- update the preview duration on a 1 second cadence and cover the new opened_at behavior with tests

## Testing
- bun test src/store/db.test.ts
- bunx tsc --noEmit